### PR TITLE
docs: 📽️ Add iOS 26 demo GIF to README hero section

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ Smart City Exploration allows users to:
 
 ---
 
+## 📽️ Live Demo – iOS 26
+
+> ✅ Fully native SwiftUI architecture  
+> 🧱 Clean modular design using SwiftData, MapKit, Amplitude  
+> 📲 Universal layout for iPhone & iPad (iOS 18 through iOS 26)
+
+![](vid/iOS26Animation.gif)
+
+> 💡 Captured using Xcode 16 Beta on iOS 26 Simulator
+
+---
 
 ### 📸 App UI Showcase
 

--- a/Smart City/App/AppCoordinator.swift
+++ b/Smart City/App/AppCoordinator.swift
@@ -7,7 +7,7 @@
 import SwiftUI
 
 /// Manages high-level navigation across feature flows.
-///
+/// 
 /// `AppCoordinator` is injected into view models and views to control push, pop,
 /// sheet presentation, and deep-linking logic. It abstracts routing across compact
 /// and split view environments.

--- a/Smart City/App/AppCoordinator.swift
+++ b/Smart City/App/AppCoordinator.swift
@@ -7,7 +7,7 @@
 import SwiftUI
 
 /// Manages high-level navigation across feature flows.
-/// 
+///
 /// `AppCoordinator` is injected into view models and views to control push, pop,
 /// sheet presentation, and deep-linking logic. It abstracts routing across compact
 /// and split view environments.


### PR DESCRIPTION
This commit adds a prominently placed demo section to the top of the README, showcasing the Smart City app running on iOS 26.

🎥 What's included:
- GIF embed of full flow running on iOS 26 Simulator
- Positioned as a visual hero below the project title
- Highlights compatibility with iPhone, iPad, iOS 18 through iOS 26
- Notes Xcode 16 Beta environment for transparency

This visual summary improves first impressions for reviewers and demonstrates production-readiness across latest Apple platforms.