### PR TITLE
docs: 📽️ Add iOS 26 demo GIF to README hero section

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Smart City Exploration allows users to:
 > 🧱 Clean modular design using SwiftData, MapKit, Amplitude  
 > 📲 Universal layout for iPhone & iPad (iOS 18 through iOS 26)
 
-![](vid/iOS26Animation.gif)
+![](vid/img/iOS26Animation.gif)
 
 > 💡 Captured using Xcode 16 Beta on iOS 26 Simulator
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Smart City Exploration allows users to:
 > 🧱 Clean modular design using SwiftData, MapKit, Amplitude  
 > 📲 Universal layout for iPhone & iPad (iOS 18 through iOS 26)
 
-![](vid/img/iOS26Animation.gif)
+![](docs/vid/iOS26Animation.gif)
 
 > 💡 Captured using Xcode 16 Beta on iOS 26 Simulator
 


### PR DESCRIPTION
This commit adds a prominently placed demo section to the top of the README, showcasing the Smart City app running on iOS 26.

🎥 What's included:
- GIF embed of full flow running on iOS 26 Simulator
- Positioned as a visual hero below the project title
- Highlights compatibility with iPhone, iPad, iOS 18 through iOS 26
- Notes Xcode 16 Beta environment for transparency
